### PR TITLE
Pass cwd option to glob.sync

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -24,12 +24,12 @@ function runTypeScriptCompiler(logger, projectDir, options) {
 		if (!fs.existsSync(tsconfigPath)) {
 			throw Error('No tsconfig.json file found in project.');
 		}
-		expandFilesGlob(tsconfigPath);
+		expandFilesGlob(tsconfigPath, projectDir);
 
 		var nodeArgs = [tscPath, '--project', projectDir];
 		if (options.watch) {
 			nodeArgs.push('--watch');
-			watchForGlobUpdates(tsconfigPath);
+			watchForGlobUpdates(tsconfigPath, projectDir);
 		}
 
 		var tsc = spawn(process.execPath, nodeArgs, { stdio: 'inherit' });
@@ -44,7 +44,7 @@ function runTypeScriptCompiler(logger, projectDir, options) {
 	});
 }
 
-function expandFilesGlob(tsconfigPath) {
+function expandFilesGlob(tsconfigPath, projectDir) {
 	var tsconfig = JSON.parse(fs.readFileSync(tsconfigPath));
 	if (!(tsconfig.filesGlob instanceof Array)) {
 		return;
@@ -65,7 +65,7 @@ function expandFilesGlob(tsconfigPath) {
 	});
 
 	var allFiles = searchList.map(function (fileGlob) {
-		return glob.sync(fileGlob, { ignore: ignoreList });
+		return glob.sync(fileGlob, { ignore: ignoreList, cwd: projectDir });
 	});
 	allFiles = _.flatten(allFiles);
 	allFiles.sort();
@@ -77,7 +77,7 @@ function expandFilesGlob(tsconfigPath) {
 	}
 }
 
-function watchForGlobUpdates(tsconfigPath) {
+function watchForGlobUpdates(tsconfigPath, projectDir) {
 	var Gaze = require('gaze').Gaze;
 
 	var tsconfig = JSON.parse(fs.readFileSync(tsconfigPath));
@@ -87,7 +87,7 @@ function watchForGlobUpdates(tsconfigPath) {
 	}
 
 	var update = function () {
-		expandFilesGlob(tsconfigPath);
+		expandFilesGlob(tsconfigPath, projectDir);
 	};
 
 	new Gaze(globs)


### PR DESCRIPTION
When cli is used with `--path` option, the current working directory (cwd) is not the project dir.
`glob.sync` is working with the files in the current working dir, so always pass the projectDir as cwd.
