### PR TITLE
Modify tsconfig creation

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -27,7 +27,10 @@ function createTsconfig() {
 		target: "es5",
 		inlineSourceMap: true,
 		experimentalDecorators: true,
+		noEmitHelpers: true,
 	};
+
+	tsconfig.exclude = ['node_modules/typescript'];
 
 	var coreModulesPath = 'node_modules/tns-core-modules/';
 	var coreModulesTypingsPath = 'node_modules/tns-core-modules/tns-core-modules.d.ts';
@@ -40,20 +43,6 @@ function createTsconfig() {
 	} catch (err) {
 		console.warn('tns-core-modules/package.json: ' + err.toString());
 	}
-
-
-	var expectedGlobs = [
-		'app/**/*.ts',
-		coreModulesTypingsPath,
-	];
-
-	tsconfig.files = tsconfig.files || [];
-	var files = tsconfig.filesGlob = tsconfig.filesGlob || [];
-	expectedGlobs.forEach(function (glob) {
-		if (files.indexOf(glob) === -1) {
-			files.unshift(glob);
-		}
-	});
 
 	fs.writeFileSync(tsconfigPath, JSON.stringify(tsconfig, null, 4));
 }


### PR DESCRIPTION
Drop files array and filesGlob as they are not needed for autocompletion or compilation.
Exclude typescript node_module from compilation due to duplicate identifier clashes.
Note that a user has to exclude other node_modules which may hinder compilation by hand!
Ping @rosen-vladimirov 
