### PR TITLE
generate tsconfig.json from the source file name tsconfig.json.default

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -20,16 +20,17 @@ function runTypeScriptCompiler(logger, projectDir, options) {
 			throw Error('TypeScript installation local to project was not found. Install by executing `npm install typescript`.');
 		}
 
-		var tsconfigPath = path.join(projectDir, 'tsconfig.json');
-		if (!fs.existsSync(tsconfigPath)) {
-			throw Error('No tsconfig.json file found in project.');
+		var sourceTsconfigPath = path.join(projectDir, 'tsconfig.json.default');
+		var destTsconfigPath = path.join(projectDir, 'tsconfig.json');
+		if (!fs.existsSync(sourceTsconfigPath)) {
+			throw Error('No tsconfig.json.default file found in project.');
 		}
-		expandFilesGlob(tsconfigPath, projectDir);
+		expandFilesGlob(sourceTsconfigPath, destTsconfigPath, projectDir);
 
 		var nodeArgs = [tscPath, '--project', projectDir];
 		if (options.watch) {
 			nodeArgs.push('--watch');
-			watchForGlobUpdates(tsconfigPath, projectDir);
+			watchForGlobUpdates(sourceTsconfigPath, destTsconfigPath, projectDir);
 		}
 
 		var tsc = spawn(process.execPath, nodeArgs, { stdio: 'inherit' });
@@ -44,8 +45,8 @@ function runTypeScriptCompiler(logger, projectDir, options) {
 	});
 }
 
-function expandFilesGlob(tsconfigPath, projectDir) {
-	var tsconfig = JSON.parse(fs.readFileSync(tsconfigPath));
+function expandFilesGlob(sourceTsconfigPath, destTsconfigPath, projectDir) {
+	var tsconfig = JSON.parse(fs.readFileSync(sourceTsconfigPath));
 	if (!(tsconfig.filesGlob instanceof Array)) {
 		return;
 	}
@@ -73,26 +74,26 @@ function expandFilesGlob(tsconfigPath, projectDir) {
 
 	if (!_.isEqual(tsconfig.files, allFiles)) {
 		tsconfig.files = allFiles;
-		fs.writeFileSync(tsconfigPath, JSON.stringify(tsconfig, null, 2));
+		fs.writeFileSync(destTsconfigPath, JSON.stringify(tsconfig, null, 2));
 	}
 }
 
-function watchForGlobUpdates(tsconfigPath, projectDir) {
+function watchForGlobUpdates(sourceTsconfigPath, destTsconfigPath, projectDir) {
 	var Gaze = require('gaze').Gaze;
 
-	var tsconfig = JSON.parse(fs.readFileSync(tsconfigPath));
+	var tsconfig = JSON.parse(fs.readFileSync(sourceTsconfigPath));
 	var globs = tsconfig.filesGlob;
 	if (!(globs instanceof Array)) {
 		return;
 	}
 
 	var update = function () {
-		expandFilesGlob(tsconfigPath, projectDir);
+		expandFilesGlob(sourceTsconfigPath, destTsconfigPath, projectDir);
 	};
 
 	new Gaze(globs)
 		.on('added', update)
 		.on('deleted', update);
 
-	new Gaze(tsconfigPath).on('changed', update);
+	new Gaze(sourceTsconfigPath).on('changed', update);
 }


### PR DESCRIPTION
Sometimes we only define the "filesGlob" block in tsconfig.json, but the tsconfig.json will updated the "files" block while new files added or deleted. This is not kind enough for teamwork, since we need pay attention to handle file conflicts while more than one team member add new typescript source files. 
My suggestion is that define "filesGlob" block in tsconfig.json.default and leave tsconfig.json out of version control.
