### PR TITLE
Delete obsolete files glob code

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -3,8 +3,6 @@ exports.runTypeScriptCompiler = runTypeScriptCompiler;
 var spawn = require('child_process').spawn;
 var fs = require('fs');
 var path = require('path');
-var glob = require('glob');
-var _ = require('lodash');
 
 function runTypeScriptCompiler(logger, projectDir, options) {
 	return new Promise(function (resolve, reject) {
@@ -24,12 +22,10 @@ function runTypeScriptCompiler(logger, projectDir, options) {
 		if (!fs.existsSync(tsconfigPath)) {
 			throw Error('No tsconfig.json file found in project.');
 		}
-		expandFilesGlob(tsconfigPath, projectDir);
 
 		var nodeArgs = [tscPath, '--project', projectDir];
 		if (options.watch) {
 			nodeArgs.push('--watch');
-			watchForGlobUpdates(tsconfigPath, projectDir);
 		}
 
 		var tsc = spawn(process.execPath, nodeArgs, { stdio: 'inherit' });
@@ -42,57 +38,4 @@ function runTypeScriptCompiler(logger, projectDir, options) {
 			}
 		});
 	});
-}
-
-function expandFilesGlob(tsconfigPath, projectDir) {
-	var tsconfig = JSON.parse(fs.readFileSync(tsconfigPath));
-	if (!(tsconfig.filesGlob instanceof Array)) {
-		return;
-	}
-
-	var ignoreList = [];
-	var searchList = [];
-
-	tsconfig.filesGlob.forEach(function (fileGlob) {
-		if (typeof fileGlob !== 'string') {
-			return;
-		}
-		if (fileGlob[0] === '!') {
-			ignoreList.push(fileGlob);
-		} else {
-			searchList.push(fileGlob);
-		}
-	});
-
-	var allFiles = searchList.map(function (fileGlob) {
-		return glob.sync(fileGlob, { ignore: ignoreList, cwd: projectDir });
-	});
-	allFiles = _.flatten(allFiles);
-	allFiles.sort();
-	allFiles = _.unique(allFiles);
-
-	if (!_.isEqual(tsconfig.files, allFiles)) {
-		tsconfig.files = allFiles;
-		fs.writeFileSync(tsconfigPath, JSON.stringify(tsconfig, null, 2));
-	}
-}
-
-function watchForGlobUpdates(tsconfigPath, projectDir) {
-	var Gaze = require('gaze').Gaze;
-
-	var tsconfig = JSON.parse(fs.readFileSync(tsconfigPath));
-	var globs = tsconfig.filesGlob;
-	if (!(globs instanceof Array)) {
-		return;
-	}
-
-	var update = function () {
-		expandFilesGlob(tsconfigPath, projectDir);
-	};
-
-	new Gaze(globs)
-		.on('added', update)
-		.on('deleted', update);
-
-	new Gaze(tsconfigPath).on('changed', update);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-dev-typescript",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "TypeScript support for NativeScript projects. Install using `tns install typescript`.",
   "scripts": {
     "test": "exit 0",
@@ -27,9 +27,6 @@
     "url": "https://github.com/NativeScript/nativescript-dev-typescript.git"
   },
   "dependencies": {
-    "gaze": "^0.5.2",
-    "glob": "^5.0.15",
-    "lodash": "^3.10.1",
     "nativescript-hook": "^0.2.0"
   }
 }


### PR DESCRIPTION
Since the `filesGlob` property is no longer used all code related to it is practically obsolete and can be removed.
Ping @rosen-vladimirov for a quick review
