### PR TITLE
Generate source maps as separate file, instead of inlining them.

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -35,7 +35,7 @@ function createTsconfig() {
 	tsconfig.compilerOptions = tsconfig.compilerOptions || {
 		module: "commonjs",
 		target: "es5",
-		inlineSourceMap: true,
+		sourceMap: true,
 		experimentalDecorators: true,
 		noEmitHelpers: true,
 	};


### PR DESCRIPTION
The default option in the `tsconfig` file appends the source maps to the actual `js` file which is deployed on the device. This way the app size is unnecessarily increased with the size of all source maps.
Is there any benefit to inlining the source maps which I am not aware of?
