### PR TITLE
Fix double restart when --watch is used

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -28,13 +28,34 @@ function runTypeScriptCompiler(logger, projectDir, options) {
 			nodeArgs.push('--watch');
 		}
 
-		var tsc = spawn(process.execPath, nodeArgs, { stdio: 'inherit' });
-		tsc.on('exit', function (code, signal) {
-			// EmitReturnStatus enum in https://github.com/Microsoft/TypeScript/blob/8947757d096338532f1844d55788df87fb5a39ed/src/compiler/types.ts#L605
-			if (code === 0 || code === 2 || code === 3) {
+		var tsc = spawn(process.execPath, nodeArgs);
+		var isResolved = false;
+		tsc.stdout.on('data', function(data) {
+			var stringData = data.toString();
+			logger.info(stringData);
+			if(options.watch && stringData.toLowerCase().indexOf("compilation complete. watching for file changes.") !== -1 && !isResolved) {
+				isResolved = true;
 				resolve();
-			} else {
-				reject(Error('TypeScript compiler failed with exit code ' + code));
+			}
+		});
+
+		tsc.stderr.on('data', function(data) {
+			logger.info(data.toString());
+		});
+
+		tsc.on('error', function(err) {
+			logger.info(err.message);
+		});
+
+		tsc.on('exit', function (code, signal) {
+			if(!isResolved) {
+				isResolved = true;
+				// EmitReturnStatus enum in https://github.com/Microsoft/TypeScript/blob/8947757d096338532f1844d55788df87fb5a39ed/src/compiler/types.ts#L605
+				if (code === 0 || code === 2 || code === 3) {
+					resolve();
+				} else {
+					reject(Error('TypeScript compiler failed with exit code ' + code));
+				}
 			}
 		});
 	});

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -1,9 +1,5 @@
 var compiler = require('./compiler');
 
 module.exports = function ($logger, $projectData, $errors) {
-	compiler.runTypeScriptCompiler($logger, $projectData.projectDir, { watch: true })
-		.then(function () { },
-			function (err) {
-				$errors.failWithoutHelp(err.toString());
-			})
+	return compiler.runTypeScriptCompiler($logger, $projectData.projectDir, { watch: true });
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-dev-typescript",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "TypeScript support for NativeScript projects. Install using `tns install typescript`.",
   "scripts": {
     "test": "exit 0",


### PR DESCRIPTION
When `tns livesync <platform> --watch` is executed, the application is restarted twice as typescript's watch command is compiling the sources again.
CLI starts the watch command last, after the app is already started on the device. The watch command is compiling the .ts files to .js. CLI detects these changes and restarts the app.
In order to fix this, make the watch hook to return a promise. CLI will not start "watching" for file changes until the promise is resolved.
The watch hook's promise will be resolved when the following message is printed by TypeScript compiler: "Compilation complete. Watching for file changes.".
