### PR TITLE
Do not touch references.d.ts, if it exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-dev-typescript",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "TypeScript support for NativeScript projects. Install using `tns install typescript`.",
   "scripts": {
     "test": "exit 0",

--- a/postinstall.js
+++ b/postinstall.js
@@ -15,7 +15,7 @@ function createReferenceFile() {
 	var referenceFilePath = path.join(projectDir, 'references.d.ts'),
 		content = '/// <reference path="./node_modules/tns-core-modules/tns-core-modules.d.ts" /> Needed for autocompletion and compilation.';
 
-	if (!fs.existsSync(referenceFilePath) || fs.readFileSync(referenceFilePath, { encoding: 'utf8' }).indexOf(content) === -1) {
+	if (!fs.existsSync(referenceFilePath)) {
 		fs.appendFileSync(referenceFilePath, content);
 	}
 }


### PR DESCRIPTION
The previous implementation always included a reference to `tns-core-modules.d.ts` which is **not** the correct file to use in Angular projects. The simplest way to avoid that is to prevent modifying the file if it exists, and manually edit it (and use the right reference in project templates).
