### PR TITLE
Do not overwrite typescript dependency

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -45,8 +45,13 @@ function runTypeScriptCompiler(logger, projectDir, options) {
 
 		tsc.on('error', function(err) {
 			logger.info(err.message);
+			if(!isResolved) {
+				isResolved = true;
+				reject(err);
+			}
 		});
 
+		// TODO: Consider using close event instead of exit
 		tsc.on('exit', function (code, signal) {
 			if(!isResolved) {
 				isResolved = true;

--- a/postinstall.js
+++ b/postinstall.js
@@ -57,12 +57,31 @@ function createTsconfig() {
 	fs.writeFileSync(tsconfigPath, JSON.stringify(tsconfig, null, 4));
 }
 
+function getProjectTypeScriptVersion() {
+	try {
+		var packageJsonPath = path.join(projectDir, "package.json"),
+			packageJsonContent = fs.readFileSync(packageJsonPath, "utf8"),
+			jsonContent = JSON.parse(packageJsonContent);
+
+		return (jsonContent.dependencies && jsonContent.dependencies.typescript)
+			|| (jsonContent.devDependencies && jsonContent.devDependencies.typescript);
+	} catch(err) {
+		console.error(err);
+		return null;
+	}
+}
+
 function installTypescript() {
-	require('child_process').exec('npm install --save-dev typescript', { cwd: projectDir }, function (err, stdout, stderr) {
-		if (err) {
-			console.warn('npm: ' + err.toString());
-		}
-		process.stdout.write(stdout);
-		process.stderr.write(stderr);
-	});
+	var installedTypeScriptVersion = getProjectTypeScriptVersion();
+	if(installedTypeScriptVersion) {
+		console.log("Project already targets TypeScript " + installedTypeScriptVersion);
+	} else {
+		require('child_process').exec('npm install --save-dev typescript', { cwd: projectDir }, function (err, stdout, stderr) {
+			if (err) {
+				console.warn('npm: ' + err.toString());
+			}
+			process.stdout.write(stdout);
+			process.stderr.write(stderr);
+		});
+	}
 }


### PR DESCRIPTION
When you call `npm install --save-dev <package>` npm does not consider the current version of the package from devDependencies and always installs latest one.
So when the postinstall script of the `nativescript-dev-typescript` is executed, it always updates typescript dependency to the latest version.

Fix this by explicitly checking if there's already typescript dependency and do not call `npm install` in such case.
Fixes https://github.com/NativeScript/nativescript-dev-typescript/issues/12
### Reject the promise when tsc errors

When the child process that has to transpile the TypeScript emits error event, it might not raise "exit" as the process itself might not start at all.
In this case we have to reject the promise.
