### PR TITLE
Use inline source maps for Chrome DevTools debugging

### DIFF
--- a/lib/before-prepare.js
+++ b/lib/before-prepare.js
@@ -6,5 +6,5 @@ module.exports = function ($logger, $projectData, $usbLiveSyncService) {
 	if (liveSync || bundle) {
 		return;
 	}
-	return compiler.runTypeScriptCompiler($logger, $projectData.projectDir);
+	return compiler.runTypeScriptCompiler($logger, $projectData.projectDir, { release: $projectData.$options.release });
 }

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -28,6 +28,15 @@ function runTypeScriptCompiler(logger, projectDir, options) {
 			nodeArgs.push('--watch');
 		}
 
+		if (!options.release) {
+			// For debugging in Chrome DevTools
+			nodeArgs.push(
+				'--sourceMap', 'false',
+				'--inlineSourceMap', 'true',
+				'--inlineSources', 'true'
+			);
+		}
+
 		var tsc = spawn(process.execPath, nodeArgs);
 		var isResolved = false;
 		tsc.stdout.on('data', function(data) {

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -1,5 +1,5 @@
 var compiler = require('./compiler');
 
 module.exports = function ($logger, $projectData, $errors) {
-	return compiler.runTypeScriptCompiler($logger, $projectData.projectDir, { watch: true });
+	return compiler.runTypeScriptCompiler($logger, $projectData.projectDir, { watch: true, release: $projectData.$options.release });
 }

--- a/postinstall.js
+++ b/postinstall.js
@@ -27,7 +27,6 @@ function createTsconfig() {
 	tsconfig.compilerOptions = {
 		module: "commonjs",
 		target: "es5",
-		sourceMap: true,
 		experimentalDecorators: true,
 		emitDecoratorMetadata: true,
 		noEmitHelpers: true,


### PR DESCRIPTION
Using [multiple configurations](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-1.html#configuration-inheritance) wouldn't possible at the moment, because that would require TypeScript 2.1 so use command line options instead.

> Compiler options specified on the command line override those specified in the tsconfig.json file. 
> -- <cite>https://github.com/Microsoft/TypeScript/pull/1692</cite>

Ping @blagoev, @KristinaKoeva, @slavchev