### PR TITLE
Workaround boolean flags not available in TS 2.0

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -30,14 +30,12 @@ function runTypeScriptCompiler(logger, projectDir, options) {
 
 		if (!options.release) {
 			// For debugging in Chrome DevTools
-			nodeArgs.push(
-				'--sourceMap', 'false',
-				'--inlineSourceMap', 'true',
-				'--inlineSources', 'true'
-			);
+			nodeArgs.push('--inlineSourceMap', '--inlineSources');
 		}
 
+		logger.trace(process.execPath, nodeArgs.join(' '));
 		var tsc = spawn(process.execPath, nodeArgs);
+
 		var isResolved = false;
 		tsc.stdout.on('data', function(data) {
 			var stringData = data.toString();


### PR DESCRIPTION
If a valid `tsconfig.json` file exists, delete the `sourceMap` option if it exists on postinstall.

https://github.com/Microsoft/TypeScript/pull/11798

Ping @dtopuzov, @pkoleva 