### PR TITLE
Add required TypeScript libs automatically: dom, es6, etc.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-dev-typescript",
-  "version": "0.3.8",
+  "version": "0.4.0",
   "description": "TypeScript support for NativeScript projects. Install using `tns install typescript`.",
   "scripts": {
     "test": "exit 0",

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,12 +1,19 @@
-var hook = require('nativescript-hook')(__dirname);
+var hook = require("nativescript-hook")(__dirname);
 hook.postinstall();
 
-var fs = require('fs');
-var path = require('path');
+var fs = require("fs");
+var path = require("path");
+
+var __migrations = [
+	inlineSourceMapMigration,
+	addDomLibs,
+	addIterableToAngularProjects,
+];
+
 
 var projectDir = hook.findProjectDir();
 if (projectDir) {
-	var tsconfigPath = path.join(projectDir, 'tsconfig.json');
+	var tsconfigPath = path.join(projectDir, "tsconfig.json");
 	if (fs.existsSync(tsconfigPath)) {
 		migrateTsconfig(tsconfigPath);
 	} else {
@@ -17,7 +24,7 @@ if (projectDir) {
 }
 
 function createReferenceFile() {
-	var referenceFilePath = path.join(projectDir, 'references.d.ts'),
+	var referenceFilePath = path.join(projectDir, "references.d.ts"),
 		content = '/// <reference path="./node_modules/tns-core-modules/tns-core-modules.d.ts" /> Needed for autocompletion and compilation.';
 
 	if (!fs.existsSync(referenceFilePath)) {
@@ -25,26 +32,75 @@ function createReferenceFile() {
 	}
 }
 
-function migrateTsconfig(tsconfigPath) {
-	var displaybleTsconfigPath = path.relative(projectDir, tsconfigPath);
-
-	try {
-		var existingConfigContents = fs.readFileSync(tsconfigPath);
-		var existingConfig = JSON.parse(existingConfigContents);
-	} catch (e) {
-		console.error("Invalid " + displaybleTsconfigPath + ": " + e);
-		return;
-	}
-
-	if (existingConfig["compilerOptions"]) {
+function inlineSourceMapMigration(existingConfig, displayableTsconfigPath) {
+	if (existingConfig.compilerOptions) {
 		if ("sourceMap" in existingConfig["compilerOptions"]) {
 			delete existingConfig["compilerOptions"]["sourceMap"];
-			console.warn("> Deleted \"compilerOptions.sourceMap\" setting in \"" + displaybleTsconfigPath + "\".");
+			console.warn("> Deleted \"compilerOptions.sourceMap\" setting in \"" + displayableTsconfigPath + "\".");
 			console.warn("> Inline source maps will be used when building in Debug configuration from now on.");
 		}
 	}
+}
 
-	fs.writeFileSync(tsconfigPath, JSON.stringify(existingConfig, null, 4));
+function addIterableToAngularProjects(existingConfig) {
+	var packageJsonPath = path.join(projectDir, "package.json");
+	var packageJson = JSON.parse(fs.readFileSync(packageJsonPath));
+	var dependencies = packageJson.dependencies || [];
+
+	var hasAngular = Object.keys(dependencies).includes("nativescript-angular");
+	if (hasAngular) {
+		addTsLib(existingConfig, "es2015.iterable");
+	}
+}
+
+function addDomLibs(existingConfig) {
+	var packageJsonPath = path.join(projectDir, "package.json");
+	var packageJson = JSON.parse(fs.readFileSync(packageJsonPath));
+	var dependencies = packageJson.dependencies || [];
+
+	var hasRelevantModules = dependencies["tns-core-modules"] &&
+		/[3-9]\.\d+\.\d+/i.test(dependencies["tns-core-modules"]);
+	if (hasRelevantModules) {
+		addTsLib(existingConfig, "es6");
+		addTsLib(existingConfig, "dom");
+	}
+}
+
+function addTsLib(existingConfig, libName) {
+	if (existingConfig.compilerOptions) {
+		var options = existingConfig.compilerOptions;
+		if (!options.lib) {
+			options.lib = [];
+		}
+		if (!options.lib.find(function(l) {
+				return libName.toLowerCase() === l.toLowerCase();
+			})) {
+			options.lib.push(libName);
+		}
+	}
+}
+
+function migrateTsconfig(tsconfigPath) {
+	var displayableTsconfigPath = path.relative(projectDir, tsconfigPath);
+
+	function withTsConfig(action) {
+		var existingConfig = null;
+		try {
+			var existingConfigContents = fs.readFileSync(tsconfigPath);
+			existingConfig = JSON.parse(existingConfigContents);
+		} catch (e) {
+			console.error("Invalid " + displayableTsconfigPath + ": " + e);
+			return;
+		}
+		action(existingConfig);
+		fs.writeFileSync(tsconfigPath, JSON.stringify(existingConfig, null, 4));
+	}
+
+	withTsConfig(function(existingConfig) {
+		__migrations.forEach(function(migration) {
+			migration(existingConfig, displayableTsconfigPath);
+		});
+	});
 }
 
 function createTsconfig(tsconfigPath) {
@@ -58,8 +114,10 @@ function createTsconfig(tsconfigPath) {
 		noEmitHelpers: true,
 		noEmitOnError: true,
 	};
+	addDomLibs(tsconfig);
+	addIterableToAngularProjects(tsconfig);
 
-	tsconfig.exclude = ['node_modules', 'platforms', "**/*.aot.ts"];
+	tsconfig.exclude = ["node_modules", "platforms", "**/*.aot.ts"];
 
 	fs.writeFileSync(tsconfigPath, JSON.stringify(tsconfig, null, 4));
 }
@@ -70,8 +128,8 @@ function getProjectTypeScriptVersion() {
 			packageJsonContent = fs.readFileSync(packageJsonPath, "utf8"),
 			jsonContent = JSON.parse(packageJsonContent);
 
-		return (jsonContent.dependencies && jsonContent.dependencies.typescript)
-			|| (jsonContent.devDependencies && jsonContent.devDependencies.typescript);
+		return (jsonContent.dependencies && jsonContent.dependencies.typescript) ||
+            (jsonContent.devDependencies && jsonContent.devDependencies.typescript);
 	} catch (err) {
 		console.error(err);
 		return null;
@@ -83,9 +141,9 @@ function installTypescript() {
 	if (installedTypeScriptVersion) {
 		console.log("Project already targets TypeScript " + installedTypeScriptVersion);
 	} else {
-		require('child_process').exec('npm install --save-dev typescript', { cwd: projectDir }, function (err, stdout, stderr) {
+		require("child_process").exec("npm install --save-dev typescript", { cwd: projectDir }, function (err, stdout, stderr) {
 			if (err) {
-				console.warn('npm: ' + err.toString());
+				console.warn("npm: " + err.toString());
 			}
 			process.stdout.write(stdout);
 			process.stderr.write(stderr);


### PR DESCRIPTION
`es2015.iterator` only added to Angular projects.

Needed for modules 3.0.0+. Required by NativeScript/NativeScript#3642