### PR TITLE
 	Implement after-watch hook

### DIFF
--- a/lib/after-watch.js
+++ b/lib/after-watch.js
@@ -1,0 +1,9 @@
+var compiler = require('./compiler');
+
+module.exports = function ($logger) {
+	var tsc = compiler.getTscProcess();
+	if (tsc) {
+		$logger.info("Stopping tsc watch");
+		tsc.kill("SIGINT")
+	}
+}

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,8 +1,10 @@
 exports.runTypeScriptCompiler = runTypeScriptCompiler;
+exports.getTscProcess = getTscProcess;
 
 var spawn = require('child_process').spawn;
 var fs = require('fs');
 var path = require('path');
+var tsc = null;
 
 function runTypeScriptCompiler(logger, projectDir, options) {
 	return new Promise(function (resolve, reject) {
@@ -34,25 +36,25 @@ function runTypeScriptCompiler(logger, projectDir, options) {
 		}
 
 		logger.trace(process.execPath, nodeArgs.join(' '));
-		var tsc = spawn(process.execPath, nodeArgs);
+		tsc = spawn(process.execPath, nodeArgs);
 
 		var isResolved = false;
-		tsc.stdout.on('data', function(data) {
+		tsc.stdout.on('data', function (data) {
 			var stringData = data.toString();
 			logger.info(stringData);
-			if(options.watch && stringData.toLowerCase().indexOf("compilation complete. watching for file changes.") !== -1 && !isResolved) {
+			if (options.watch && stringData.toLowerCase().indexOf("compilation complete. watching for file changes.") !== -1 && !isResolved) {
 				isResolved = true;
 				resolve();
 			}
 		});
 
-		tsc.stderr.on('data', function(data) {
+		tsc.stderr.on('data', function (data) {
 			logger.info(data.toString());
 		});
 
-		tsc.on('error', function(err) {
+		tsc.on('error', function (err) {
 			logger.info(err.message);
-			if(!isResolved) {
+			if (!isResolved) {
 				isResolved = true;
 				reject(err);
 			}
@@ -60,15 +62,20 @@ function runTypeScriptCompiler(logger, projectDir, options) {
 
 		// TODO: Consider using close event instead of exit
 		tsc.on('exit', function (code, signal) {
-			if(!isResolved) {
+			tsc = null;
+			if (!isResolved) {
 				isResolved = true;
 				// EmitReturnStatus enum in https://github.com/Microsoft/TypeScript/blob/8947757d096338532f1844d55788df87fb5a39ed/src/compiler/types.ts#L605
 				if (code === 0 || code === 2 || code === 3) {
 					resolve();
 				} else {
-					reject(Error('TypeScript compiler failed with exit code ' + code));
+					reject(new Error('TypeScript compiler failed with exit code ' + code));
 				}
 			}
 		});
 	});
+}
+
+function getTscProcess() {
+	return tsc;
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,11 @@
         "type": "before-watch",
         "script": "lib/watch.js",
         "inject": true
+      },
+      {
+        "type": "after-watch",
+        "script": "lib/after-watch.js",
+        "inject": true
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-dev-typescript",
-  "version": "0.4.5",
+  "version": "0.5.0",
   "description": "TypeScript support for NativeScript projects. Install using `tns install typescript`.",
   "scripts": {
     "test": "exit 0",


### PR DESCRIPTION
Used for stopping the `$ tsc --watch` process. This is needed in long living processes which may work with multiple projects.

Ping @rosen-vladimirov @sis0k0 