### PR TITLE
Remove usbLiveSyncService.isInitialized check

### DIFF
--- a/lib/before-prepare.js
+++ b/lib/before-prepare.js
@@ -1,7 +1,7 @@
 var compiler = require('./compiler');
 
-module.exports = function ($logger, $projectData, $usbLiveSyncService) {
-	var liveSync = $usbLiveSyncService.isInitialized;
+module.exports = function ($logger, $projectData) {
+	var liveSync = !!compiler.getTscProcess();
 	var bundle = $projectData.$options.bundle;
 	if (liveSync || bundle) {
 		return;


### PR DESCRIPTION
In case LiveSync process is currently running, `before-prepare` hook must not run the `tsc` compiler. We've been doing this by checking a special property from CLI - `usbLiveSyncService.isInitialized`. However, there's no need to use this service - we have the information if we have started `tsc` process, so just use it instead of relying on `usbLiveSyncService`.
This will allow us to remove the usbLiveSyncService from CLI as it is no longer used anywhere.