### PR TITLE
Use bundle and release options from hookArgs

### DIFF
--- a/lib/before-prepare.js
+++ b/lib/before-prepare.js
@@ -1,10 +1,14 @@
 var compiler = require('./compiler');
 
-module.exports = function ($logger, $projectData) {
+module.exports = function ($logger, $projectData, $options, hookArgs) {
 	var liveSync = !!compiler.getTscProcess();
-	var bundle = $projectData.$options.bundle;
+	var appFilesUpdaterOptions = (hookArgs && hookArgs.appFilesUpdaterOptions) || {};
+	var bundle = $options.bundle || appFilesUpdaterOptions.bundle;
+
 	if (liveSync || bundle) {
 		return;
 	}
-	return compiler.runTypeScriptCompiler($logger, $projectData.projectDir, { release: $projectData.$options.release });
+
+	var release = $options.release || appFilesUpdaterOptions.release;
+	return compiler.runTypeScriptCompiler($logger, $projectData.projectDir, { release });
 }


### PR DESCRIPTION
In case CLI is used as a library, the `$options` is not populated with correct values. So the `--release` that would normally be passed to command-line, is not set and the `$options.release` is always false.
Same is valid for the `bundle` flag.
Instead of using the flags from `$options` use them from the hookArgs. The prepare method has `appFilesUpdaterOptions`, which contain the information for bundle and release options. Use it instead and for backwards compatibility use the `$options`.