### PR TITLE
Do not treat exit code 3 as success

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -65,8 +65,8 @@ function runTypeScriptCompiler(logger, projectDir, options) {
 			tsc = null;
 			if (!isResolved) {
 				isResolved = true;
-				// EmitReturnStatus enum in https://github.com/Microsoft/TypeScript/blob/8947757d096338532f1844d55788df87fb5a39ed/src/compiler/types.ts#L605
-				if (code === 0 || code === 2 || code === 3) {
+				// ExitStatus  enum in https://github.com/Microsoft/TypeScript/blob/master/src/compiler/types.ts#L2620
+				if (code === 0 || code === 2) {
 					resolve();
 				} else {
 					reject(new Error('TypeScript compiler failed with exit code ' + code));


### PR DESCRIPTION
According to the new [enum](https://github.com/Microsoft/TypeScript/blob/master/src/compiler/types.ts#L2620) `tsc` only emits files if it exits with 0 or 2

One case where `tsc` exits with exit code 3 is `JavaScript heap out of memory` in which case the code should fail rather than succeed.

Ping @rosen-vladimirov @sis0k0 