### PR TITLE
feat(watch): use before-watchPatterns hook

### DIFF
--- a/lib/before-watchPatterns.js
+++ b/lib/before-watchPatterns.js
@@ -1,0 +1,11 @@
+module.exports = function (hookArgs) {
+	if (hookArgs.liveSyncData && !hookArgs.liveSyncData.bundle) {
+		return (args, originalMethod) => {
+			return originalMethod().then(originalPatterns => {
+				originalPatterns.push("!app/**/*.ts");
+
+				return originalPatterns;
+			});
+		};
+	}
+}

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -1,5 +1,13 @@
 var compiler = require('./compiler');
 
-module.exports = function ($logger, $projectData, $errors) {
+module.exports = function ($logger, $projectData, $errors, hookArgs) {
+	if (hookArgs.config) {
+		const appFilesUpdaterOptions = hookArgs.config.appFilesUpdaterOptions;
+		if (appFilesUpdaterOptions.bundle) {
+			$logger.warn("Hook skipped because bundling is in progress.")
+			return;
+		}
+	}
+
 	return compiler.runTypeScriptCompiler($logger, $projectData.projectDir, { watch: true, release: $projectData.$options.release });
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,11 @@
         "inject": true
       },
       {
+        "type": "before-watchPatterns",
+        "script": "lib/before-watchPatterns.js",
+        "inject": true
+      },
+      {
         "type": "before-watch",
         "script": "lib/watch.js",
         "inject": true


### PR DESCRIPTION
Use CLI's `before-watchPatterns` hook in order to instruct CLI not to watch `.ts` files.
In addition do not launch a `tsc` watch process when bundling, assume bundler will handle it.

Ping @rosen-vladimirov @sis0k0 

Merge after https://github.com/NativeScript/nativescript-cli/pull/3350