### PR TITLE
fix: pass args to original method

### DIFF
--- a/lib/before-watchPatterns.js
+++ b/lib/before-watchPatterns.js
@@ -1,7 +1,7 @@
 module.exports = function (hookArgs) {
 	if (hookArgs.liveSyncData && !hookArgs.liveSyncData.bundle) {
 		return (args, originalMethod) => {
-			return originalMethod().then(originalPatterns => {
+			return originalMethod(...args).then(originalPatterns => {
 				originalPatterns.push("!app/**/*.ts");
 
 				return originalPatterns;


### PR DESCRIPTION
Pass the original arguments to the original method when calling.

Ping @KristianDD @rosen-vladimirov 