### PR TITLE
Preserve watch output

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -4,7 +4,24 @@ exports.getTscProcess = getTscProcess;
 var spawn = require('child_process').spawn;
 var fs = require('fs');
 var path = require('path');
+var semver = require('semver');
 var tsc = null;
+
+function getTypeScriptVersion(typeScriptPath) {
+	try {
+		return require(path.join(typeScriptPath, 'package.json')).version;
+	} catch (err) { }
+
+	return null;
+}
+
+function shouldPreserveWatchOutput(typeScriptVersion) {
+	try {
+		return semver.gte(typeScriptVersion, "2.8.1");
+	} catch (err) { }
+
+	return false;
+}
 
 function runTypeScriptCompiler(logger, projectDir, options) {
 	return new Promise(function (resolve, reject) {
@@ -12,10 +29,10 @@ function runTypeScriptCompiler(logger, projectDir, options) {
 
 		var peerTypescriptPath = path.join(__dirname, '../../typescript');
 		var tscPath = path.join(peerTypescriptPath, 'lib/tsc.js');
+		var typeScriptVersion = getTypeScriptVersion(peerTypescriptPath);
+		
 		if (fs.existsSync(tscPath)) {
-			try {
-				logger.info('Found peer TypeScript ' + require(path.join(peerTypescriptPath, 'package.json')).version);
-			} catch (err) { }
+			logger.info(`Found peer TypeScript ${typeScriptVersion}`);
 		} else {
 			throw Error('TypeScript installation local to project was not found. Install by executing `npm install typescript`.');
 		}
@@ -35,13 +52,21 @@ function runTypeScriptCompiler(logger, projectDir, options) {
 			nodeArgs.push('--inlineSourceMap', '--inlineSources');
 		}
 
+		if (this.shouldPreserveWatchOutput(typeScriptVersion)) {
+			nodeArgs.push('--preserveWatchOutput');
+		}
+
 		logger.trace(process.execPath, nodeArgs.join(' '));
 		tsc = spawn(process.execPath, nodeArgs);
 
 		var isResolved = false;
 		tsc.stdout.on('data', function (data) {
 			var stringData = data.toString();
-			logger.info(stringData);
+			// Prevent console clear. Fixed the behaviour for typescript 2.7.1 and 2.7.2. Should be deleted after dropping support for 2.7.x version.
+			// https://github.com/Microsoft/TypeScript/blob/master/src/compiler/sys.ts#L623
+			if (stringData !== "\x1Bc") {
+				logger.info(stringData);
+			}
 			if (options.watch && stringData.toLowerCase().indexOf("compilation complete. watching for file changes.") !== -1 && !isResolved) {
 				isResolved = true;
 				resolve();

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "url": "https://github.com/NativeScript/nativescript-dev-typescript.git"
   },
   "dependencies": {
-    "nativescript-hook": "^0.2.0"
+    "nativescript-hook": "^0.2.0",
+    "semver": "5.5.0"
   }
 }


### PR DESCRIPTION
TypeScript clears console output from version 2.7.1. `tns debug` command prints debug URL on console after that typescript clears the output. So the debug command cannot be used.

## PR Checklist

- [ x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
When `tns debug` command is executed, the printed debug URL is cleared from typescript compiler. (from version 2.7.x+)

## What is the new behavior?
When `tns debug` command is executed, the printed debug URL is not cleared.

