### PR TITLE
Fix many 'file change detected' messages

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -64,9 +64,27 @@ function runTypeScriptCompiler(logger, projectDir, options) {
 			var stringData = data.toString();
 			// Prevent console clear. Fixed the behaviour for typescript 2.7.1 and 2.7.2. Should be deleted after dropping support for 2.7.x version.
 			// https://github.com/Microsoft/TypeScript/blob/master/src/compiler/sys.ts#L623
-			if (stringData !== "\x1Bc") {
-				logger.info(stringData);
+			let filteredData = stringData
+				.split("\n")
+				.map(row => row.replace("\x1Bc", ""))
+				.filter(r => !!r)
+				.join("\n");
+
+			if (filteredData) {
+				const logLevel = logger.getLevel();
+				const isTraceLogLevel = logLevel && /trace/i.test(logLevel);
+
+				if (isTraceLogLevel) {
+					nodeArgs.push("--listEmittedFiles");
+					logger.trace(filteredData);
+				}
+				
+				// https://github.com/Microsoft/TypeScript/blob/e53e56cf8212e45d0ebdd6affe462d161c7e0dc5/src/compiler/watch.ts#L160
+				if (!isTraceLogLevel && filteredData.indexOf("error") !== -1) {
+					logger.info(filteredData);
+				}
 			}
+
 			if (options.watch && stringData.toLowerCase().indexOf("watching for file changes.") !== -1 && !isResolved) {
 				isResolved = true;
 				resolve();


### PR DESCRIPTION
Fixes https://github.com/NativeScript/nativescript-cli/issues/3687

When `tns run android` command is executed, a typescript watcher is started. When project is prepared {N} CLI moves all files in platforms directory. This triggers a typescript watcher to print `File change detected. Starting incremental compilation...` message many times. This PR hides all messages from typescript compiler except errors. So the user will see only typescript errors. Actually when the command is executed with `--log trace` option, all messages from typescript compiler will be printed.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
Many `File change detected. Starting incremental compilation...` messages are printed when `tns run android` command is executed.

## What is the new behavior?
Only error messages from typescript compiler are printed.


