### PR TITLE
fix: stop syncing TS files outside the app folder (e.g. plugins in node_modules)

### DIFF
--- a/lib/before-watchPatterns.js
+++ b/lib/before-watchPatterns.js
@@ -2,7 +2,7 @@ module.exports = function (hookArgs) {
 	if (hookArgs.liveSyncData && !hookArgs.liveSyncData.bundle) {
 		return (args, originalMethod) => {
 			return originalMethod(...args).then(originalPatterns => {
-				originalPatterns.push("!app/**/*.ts");
+				originalPatterns.push("!**/*.ts");
 
 				return originalPatterns;
 			});


### PR DESCRIPTION
## What is the current behavior?
The plugin ts files are synced during livesync.

## What is the new behavior?
Only the js files of the plugin are synced during livesync.