### PR TITLE
fix: fix the error messages filter for typescript 3.1 as the new "Found 0 errors. Watching for file changes." info message was matching the errors filter

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -6,6 +6,12 @@ var fs = require('fs');
 var path = require('path');
 var semver = require('semver');
 var tsc = null;
+var TscCompilationCompleteMessage = "watching for file changes";
+var TscWatcherInfoMessages = [
+	"file change detected",
+	"starting incremental compilation",
+	TscCompilationCompleteMessage
+];
 
 function getTypeScriptVersion(typeScriptPath) {
 	try {
@@ -30,7 +36,7 @@ function runTypeScriptCompiler(logger, projectDir, options) {
 		var peerTypescriptPath = path.join(__dirname, '../../typescript');
 		var tscPath = path.join(peerTypescriptPath, 'lib/tsc.js');
 		var typeScriptVersion = getTypeScriptVersion(peerTypescriptPath);
-		
+
 		if (fs.existsSync(tscPath)) {
 			logger.info(`Found peer TypeScript ${typeScriptVersion}`);
 		} else {
@@ -56,6 +62,12 @@ function runTypeScriptCompiler(logger, projectDir, options) {
 			nodeArgs.push('--preserveWatchOutput');
 		}
 
+		const logLevel = logger.getLevel();
+		const isTraceLogLevel = logLevel && /trace/i.test(logLevel);
+		if (isTraceLogLevel) {
+			nodeArgs.push("--listEmittedFiles");
+		}
+
 		logger.trace(process.execPath, nodeArgs.join(' '));
 		tsc = spawn(process.execPath, nodeArgs);
 
@@ -71,24 +83,28 @@ function runTypeScriptCompiler(logger, projectDir, options) {
 				.join("\n");
 
 			if (filteredData) {
-				const logLevel = logger.getLevel();
-				const isTraceLogLevel = logLevel && /trace/i.test(logLevel);
+				var infoMessage = TscWatcherInfoMessages.find((info) => filteredData.toLowerCase().indexOf(info) !== -1);
+				if (infoMessage) {
+					if (options.watch && !isResolved && infoMessage === TscCompilationCompleteMessage) {
+						isResolved = true;
+						resolve();
+					}
+
+					// ignore these info messages as they are spamming the CLI output
+					// on each file generated in the platforms folder during prepare
+					return;
+				}
 
 				if (isTraceLogLevel) {
-					nodeArgs.push("--listEmittedFiles");
 					logger.trace(filteredData);
 				}
-				
+
 				// https://github.com/Microsoft/TypeScript/blob/e53e56cf8212e45d0ebdd6affe462d161c7e0dc5/src/compiler/watch.ts#L160
 				if (!isTraceLogLevel && filteredData.indexOf("error") !== -1) {
 					logger.info(filteredData);
 				}
 			}
 
-			if (options.watch && stringData.toLowerCase().indexOf("watching for file changes.") !== -1 && !isResolved) {
-				isResolved = true;
-				resolve();
-			}
 		});
 
 		tsc.stderr.on('data', function (data) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-dev-typescript",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "TypeScript support for NativeScript projects. Install using `tns install typescript`.",
   "scripts": {
     "test": "exit 0",


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing

Related to: https://github.com/NativeScript/nativescript-cli/issues/4135

