### PR TITLE
chore: revert the tilde resolution as it was removed by mistake

### DIFF
--- a/tsconfig-upgrader.js
+++ b/tsconfig-upgrader.js
@@ -5,6 +5,7 @@ var __migrations = [
 	inlineSourceMapMigration,
 	addDomLibs,
 	addIterableToAngularProjects,
+	addTnsCoreModulesPathMappings,
 ];
 
 function migrateProject(tsConfig, tsconfigPath, projectDir) {
@@ -78,6 +79,19 @@ function addTsLib(existingConfig, libName) {
 			options.lib.push(libName);
 		}
 	}
+}
+
+function addTnsCoreModulesPathMappings(existingConfig, displayableTsconfigPath, projectDir) {
+	console.log("Adding tns-core-modules path mappings lib to tsconfig.json...");
+	existingConfig["compilerOptions"] = existingConfig["compilerOptions"] || {};
+	var compilerOptions = existingConfig["compilerOptions"];
+	compilerOptions["baseUrl"] = ".";
+	compilerOptions["paths"] = compilerOptions["paths"] || {};
+
+	const appPath = getAppPath(projectDir);
+	compilerOptions["paths"]["~/*"] = compilerOptions["paths"]["~/*"] || [
+		`${appPath}/*`
+	];
 }
 
 function getAppPath(projectDir) {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
The tilde resolution stopped working as we removed it along with the short imports deprecation.

## What is the new behavior?
Only the short imports handling is removed from the paths and the tilde support is back again. 
