### PR TITLE
fix: print messages from hooks only with `--log trace`

### DIFF
--- a/lib/after-watch.js
+++ b/lib/after-watch.js
@@ -3,7 +3,7 @@ var compiler = require('./compiler');
 module.exports = function ($logger) {
 	var tsc = compiler.getTscProcess();
 	if (tsc) {
-		$logger.info("Stopping tsc watch");
+		$logger.trace("Stopping tsc watch");
 		tsc.kill("SIGINT")
 	}
 }

--- a/lib/before-prepare.js
+++ b/lib/before-prepare.js
@@ -6,7 +6,7 @@ module.exports = function ($logger, $projectData, $options, hookArgs) {
 	var bundle = $options.bundle || appFilesUpdaterOptions.bundle;
 
 	if (liveSync || bundle) {
-		$logger.warn("Hook skipped because either bundling or livesync is in progress.")
+		$logger.trace("Hook skipped because either bundling or livesync is in progress.")
 		return;
 	}
 

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -4,7 +4,7 @@ module.exports = function ($logger, $projectData, $errors, hookArgs) {
 	if (hookArgs.config) {
 		const appFilesUpdaterOptions = hookArgs.config.appFilesUpdaterOptions;
 		if (appFilesUpdaterOptions.bundle) {
-			$logger.warn("Hook skipped because bundling is in progress.")
+			$logger.trace("Hook skipped because bundling is in progress.")
 			return;
 		}
 	}


### PR DESCRIPTION
Currently several messages from hooks are printed as warnings or information messages. They do not have any information for the users, so move them to the trace output.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
`"Hook skipped because either bundling or livesync is in progress."` message is shown whenever `tns run <platform> --bundle` or without `--bundle` is passed.

## What is the new behavior?
`"Hook skipped because either bundling or livesync is in progress."` is in the trace logs.

Fixes issue https://github.com/NativeScript/nativescript-dev-typescript/issues/79